### PR TITLE
fix(atomic-commits): enforce AskUserQuestion tool call over plain text questions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "atomic-commits",
       "description": "Automate git commits following atomic commits and conventional commits best practices",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "WhiteKr",
         "email": "white_kr@icloud.com"

--- a/plugins/atomic-commits/.claude-plugin/plugin.json
+++ b/plugins/atomic-commits/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-commits",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Automate git commits following atomic commits and conventional commits best practices",
   "author": {
     "name": "WhiteKr",


### PR DESCRIPTION
The agent was outputting natural language questions like "진행할까요?" instead
of calling the AskUserQuestion tool, breaking the interactive conversation flow
and preventing users from clicking structured choices.

Changes:
- Add MANDATORY section at top of agent prompt with explicit anti-pattern example
- Replace YAML pseudo-code blocks with direct tool parameter descriptions
- Add "same response" directive at every Phase requiring user input
- Strengthen Critical Rule #1 with specific prohibited patterns
- Instruct declarative (period-ending) text output, delegating questions to the tool

https://claude.ai/code/session_01Lw56TsPn3zF7Ry5XEDb25f